### PR TITLE
remove $q from clusterData dependencies

### DIFF
--- a/app/js/factories.js
+++ b/app/js/factories.js
@@ -58,8 +58,7 @@ module.factory('clusterActions', [
 
 module.factory('clusterData', [
         '$http',
-        '$q',
-        function($http, $q) {
+        function($http) {
              var urlBase = 'api';
             function sendDeleteCluster(clusterName) {
                 return $http({


### PR DESCRIPTION
It appears that the $q service is not currently being used in the
clusterData service. This change removes the extra dependency.
