### PR TITLE
change template name in oshinko-deploy

### DIFF
--- a/tools/oshinko-deploy.sh
+++ b/tools/oshinko-deploy.sh
@@ -151,13 +151,13 @@ fi
 
 if [ -n "$WEBROUTE" ]
 then
-oc new-app --template oshinko \
+oc new-app --template oshinko-webui \
            -n $PROJECT \
            -p OSHINKO_CLUSTER_IMAGE=$SPARK_IMAGE \
            -p OSHINKO_WEB_IMAGE=$WEB_IMAGE \
            -p OSHINKO_WEB_ROUTE_HOSTNAME=$WEBROUTE
 else
-oc new-app --template oshinko \
+oc new-app --template oshinko-webui \
            -n $PROJECT \
            -p OSHINKO_CLUSTER_IMAGE=$SPARK_IMAGE \
            -p OSHINKO_WEB_IMAGE=$WEB_IMAGE


### PR DESCRIPTION
This adds a `-webui` to the `oshinko` in the template option to the
new-app command. OpenShift was having issues understanding which
template to use and this will correct the issue.

closes issue #32 