### PR TITLE
remove use of -e (--email), deprecated

### DIFF
--- a/tools/oshinko-setup.sh
+++ b/tools/oshinko-setup.sh
@@ -111,7 +111,7 @@ oc new-project oshinko
 # Wait for the registry to be fully up
 r=1
 while [ $r -ne 0 ]; do
-    sudo docker login -u oshinko -e "jack@jack.com" -p $(oc whoami -t) $REGISTRY
+    sudo docker login -u oshinko -p $(oc whoami -t) $REGISTRY
     r=$?
     sleep 1
 done


### PR DESCRIPTION
$ docker -v
Docker version 1.12.5, build 03508cc/1.12.5
$ docker login -e blah
Flag --email has been deprecated, will be removed in 1.13.