### PR TITLE
Modify handling and reporting of spark default image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,18 @@ WORKDIR /usr/src/app
 
 COPY ./package.json /usr/src/app/
 COPY ./bower.json /usr/src/app/
-COPY ./scripts/launch.sh /usr/src/app/
+COPY ./scripts /usr/src/app/
 
 RUN yum install -y wget git && \
     yum clean all
 
-RUN export CLI_REPO=crobby && \
-    export CLI_VER=v0.2.x.1 && \
+RUN export CLI_REPO=radanalyticsio && \
+    export CLI_VER=v0.2.5 && \
     pushd /tmp && \
-    wget https://github.com/${CLI_REPO}/oshinko-cli/releases/download/${CLI_VER}/oshinko-cli_${CLI_VER}_linux_amd64.tar.gz && \
-    tar -zxvf oshinko-cli_${CLI_VER}_linux_amd64.tar.gz && \
-    mv oshinko-cli_linux_amd64 /usr/src/app/oshinko && \
-    chmod +x /usr/src/app/oshinko && rm -rf /tmp/oshinko-cli* && \
+    wget https://github.com/${CLI_REPO}/oshinko-cli/releases/download/${CLI_VER}/oshinko_${CLI_VER}_linux_amd64.tar.gz && \
+    tar -zxvf oshinko_${CLI_VER}_linux_amd64.tar.gz && \
+    mv oshinko_linux_amd64/oshinko /usr/src/app/ && \
+    chmod +x /usr/src/app/oshinko && rm -rf /tmp/oshinko* && \
     popd
 
 RUN echo '{ "allow_root": true, "directory": "app/bower_components" }' > /usr/src/app/.bowerrc

--- a/app/forms/new-cluster.html
+++ b/app/forms/new-cluster.html
@@ -42,7 +42,7 @@
           <input id="cluster-workerconfig-name" class="form-control input-lg" type="text" ng-model="fields.workerconfigname"/>
         </div>
         <div class="form-group">
-          <label for="cluster-spark-image">Apache Spark image (only radanalyticsio/openshift-spark is supported)</label>
+          <label for="cluster-spark-image">Apache Spark image (default is SPARK_DEFAULT)</label>
           <input id="cluster-spark-image" class="form-control input-lg" type="text" ng-model="fields.sparkimage"/>
         </div>
         <div class="form-group">

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -48,7 +48,7 @@ app.run(function ($http) {
   $http.get('/config/sparkimage').success(function (result) {
     window.__env.spark_image = result;
   }).error(function (error) {
-    console.log("Unable to fetch default spark image, using default of radanalyticsio/openshift-spark. " + error);
-    window.__env.spark_image = 'radanalyticsio/openshift-spark';
+    console.log("Unable to fetch default spark image. " + error);
+    window.__env.spark_image = '';
   });
 });

--- a/release-templates.sh
+++ b/release-templates.sh
@@ -1,0 +1,20 @@
+#/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: release-templates.sh VERSION-TAG"
+    exit 1
+fi
+
+TOP_DIR=$(readlink -f `dirname "$0"` | grep -o '.*/oshinko-webui')
+mkdir -p $TOP_DIR/release_templates
+rm -rf $TOP_DIR/release_templates/*
+
+cp $TOP_DIR/tools/*.yaml $TOP_DIR/release_templates
+
+sed -r -i "s@(radanalyticsio/oshinko-webui)@\1:$1@" $TOP_DIR/release_templates/*
+
+echo "Successfully wrote templates to release_templates/ with version tag $1"
+echo
+echo "grep radanalyticsio/oshinko-webui:$1 *"
+echo
+cd $TOP_DIR/; grep radanalyticsio/oshinko-webui:$1 release_templates/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-mkdir -p ./go/src/github.com/radanalyticsio
-cd go/src/github.com/radanalyticsio
-git clone https://github.com/radanalyticsio/oshinko-cli
-cd oshinko-cli
-make build

--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$(dirname $0)/oshinko version

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
 
+# Parse the spark default image from the oshinko CLI version info
+# For a version of oshinko-web that doesn't use the CLI, the value would just be set here
+SPARK_DEFAULT=$($(dirname $0)/oshinko version | sed -rn 's/Default spark image:\s(.*)/\1/p')
+if [ -z "$SPARK_DEFAULT" ]; then
+    SPARK_DEFAULT=radanalyticsio/openshift-spark
+fi
+export SPARK_DEFAULT
+
+# Set the text label on advanced cluster create
+sed -i "s@SPARK_DEFAULT@$SPARK_DEFAULT@" app/forms/new-cluster.html
+
 export OSHINKO_SA_TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
 npm start

--- a/server.js
+++ b/server.js
@@ -17,7 +17,14 @@ var oshinko_cert = process.env.KUBERNETES_CERT || "/var/run/secrets/kubernetes.i
 var kubernetes_host = process.env.KUBERNETES_SERVICE_HOST || "kubernetes.default";
 var kubernetes_port = process.env.KUBERNETES_SERVICE_PORT || "443";
 var use_insecure_cli = process.env.USE_INSECURE_CLI || false;
-var spark_image = process.env.OSHINKO_SPARK_IMAGE || "radanalyticsio/openshift-spark";
+
+// This is a potential override from the template
+var spark_image = process.env.OSHINKO_SPARK_IMAGE;
+
+// This is the default used by the embedded CLI, determined in launch.sh
+// It's used for logging and labeling, never read and used directly
+var spark_default = process.env.SPARK_DEFAULT;
+
 var refresh_interval = process.env.OSHINKO_REFRESH_INTERVAL || 5;
 var server_token_cert = " --server=https://" + kubernetes_host + ":" + kubernetes_port + " --token=" + oshinko_sa_token + " --certificate-authority=" + oshinko_cert;
 if (use_insecure_cli) {
@@ -94,11 +101,7 @@ app.post('/api/clusters', function (request, response) {
   var mcCommand = " --masters=" + masterCount;
   var createCommand = " create " + clusterName;
   var exposeCommand = exposeWebUI ? "" : " --exposeui=false";
-  if (sparkImage === "") {
-    sparkImage = spark_image;
-  }
-  var imageCommand = " --image " + sparkImage;
-
+  var imageCommand = sparkImage ? " --image=" + sparkImage : "";
   var child_process = require('child_process');
 
   // Smash our command snippets into one command
@@ -201,4 +204,5 @@ app.listen(port, function () {
   console.log("Oshinko sa token is: " + oshinko_sa_token);
   console.log("Cert location is: " + oshinko_cert);
   console.log("Insecure mode is: " + use_insecure_cli);
+  console.log("Spark default image if not overridden is " + spark_default);
 });

--- a/tools/ui-template-no-route.yaml
+++ b/tools/ui-template-no-route.yaml
@@ -72,8 +72,7 @@ objects:
 parameters:
 - name: OSHINKO_CLUSTER_IMAGE
   description: Full name of the spark image to use when creating clusters
-  required: true
-  value: radanalyticsio/openshift-spark
+  required: false
 - name: OSHINKO_WEB_NAME
   description: Name of the oshinko web service
   value: "oshinko-web"

--- a/tools/ui-template.yaml
+++ b/tools/ui-template.yaml
@@ -82,8 +82,7 @@ objects:
 parameters:
 - name: OSHINKO_CLUSTER_IMAGE
   description: Full name of the spark image to use when creating clusters
-  required: true
-  value: radanalyticsio/openshift-spark
+  required: false
 - name: OSHINKO_WEB_NAME
   description: Name of the oshinko web service
   value: "oshinko-web"


### PR DESCRIPTION
This change modifies how the spark default image value is handled and reported. The goal is to use the CLI
default image value unless another value is explicitly given and to make that default value easier to discover.

* Make the OSHINKO_SPARK_IMAGE env var not required in the template files and give it an empty value by default.

* Do not pass the --image flag on create unless the spark image value is non-empty (ie, the OSHINKO_SPARK_IMAGE value has been set or a specific value has been given on the form)

* Add a /usr/src/app/info.sh command which can be used to report version info from an oshinko-webui image without running the server. In newer versions of the CLI this will include a default image value.

* Determine the default spark image value used by the CLI in launch.sh. Modify the label on the advanced create form to list this value as a reference, and also report this value in the console log.

* Update the Dockerfile to pull the v0.2.5 release of the oshinko CLI