### PR TITLE
Allow default spark version to be set in the image at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /usr/src/app
 COPY ./package.json /usr/src/app/
 COPY ./bower.json /usr/src/app/
 COPY ./scripts /usr/src/app/
+COPY ./sparkimage.sh /usr/src/app
 
 RUN yum install -y wget git && \
     yum clean all

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+source /usr/src/app/sparkimage.sh
 if [ -z "$SPARK_DEFAULT" ]; then
-    SPARK_DEFAULT=radanalyticsio/openshift-spark
+    SPARK_DEFAULT=$SPARK_IMAGE
 fi
 export SPARK_DEFAULT
 

--- a/sparkimage.sh
+++ b/sparkimage.sh
@@ -1,0 +1,1 @@
+SPARK_IMAGE="radanalyticsio/openshift-spark:2.2-latest"


### PR DESCRIPTION
This change adds a sparkimage.sh file which sets a value for
the env var SPARK_IMAGE.  It's read by the launch.sh script
at runtime. If SPARK_DEFAULT is not set by the webui template,
SPARK_DEFAULT will be set to $SPARK_IMAGE.