### PR TITLE
Making sure that a workercount < 0 never makes it into the actual request

### DIFF
--- a/app/js/clusterops.js
+++ b/app/js/clusterops.js
@@ -404,6 +404,11 @@ angular.module('Oshinko')
           }
           deferred.resolve(finalConfig);
         }
+        if (finalConfig["workerCount"] < 0) {
+          // default to a workerCount of 1
+          // can happen if we expected a configmap to contain a count, but it did not
+          finalConfig["workerCount"] = 1;
+        }
         return deferred.promise;
       }
 


### PR DESCRIPTION
If a given cluster config doesn't have it, we still default to 1 instead of creating a broken cluster.