### PR TITLE
[WIP] Refactor the webui integration test to support external image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,37 +66,7 @@ before_install:
   - echo $IPSTR
   - echo "****Building oshinko-webui docker image****"
   - docker build -t oshinko-webui .
-  - oc login -u system:admin > /dev/null
-  - oc project default > /dev/null 2>&1
-## Getting local docker registry so that we can push our freshly built image into it for use
-  - export REGIP=`oc get service docker-registry --template='{{index .spec.clusterIP}}:{{index .spec.ports 0 "port"}}'`
-  - echo "***Found docker-registry at $REGIP***"
-  - oc login -u developer -p test
-  - oc project myproject
-  - wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/master/resources.yaml -O master_resources.yaml
-  - echo `pwd`
-  - |
-    diff master_resources.yaml tools/resources.yaml
-    if [ "$?" -eq 0 ]; then
-      echo "No change in resources.yaml, using radanalyticsio master resources.yaml"
-      oc create -f master_resources.yaml
-    else
-      echo "local resources.yaml has changed, using local resources.yaml"
-      oc create -f tools/resources.yaml
-    fi
   - echo "My token is set to-  $(oc whoami -t)"
-  - oc policy add-role-to-user admin system:serviceaccount:myproject:oshinko -n myproject
-  - r=1; while [ $r -ne 0 ]; do docker login -u oshinko -p $(oc whoami -t) $REGIP ; r=$? ; sleep 1 ; done
-  - docker tag oshinko-webui $REGIP/myproject/oshinko-webui
-  - docker push $REGIP/myproject/oshinko-webui
-  - docker pull docker.io/radanalyticsio/openshift-spark
-  - |
-    if [ "$TO_TEST" = "secure" ]; then
-      oc new-app --template=oshinko-webui-secure -p OSHINKO_WEB_IMAGE=$REGIP/myproject/oshinko-webui
-    else
-      oc new-app --template=oshinko-webui -p OSHINKO_WEB_IMAGE=$REGIP/myproject/oshinko-webui
-    fi
-  - oc create configmap storedconfig --from-literal=mastercount=1 --from-literal=workercount=4
 install:
   - npm install
   - bower install
@@ -108,42 +78,11 @@ before_script:
   - webdriver-manager update
   - webdriver-manager start &
 script:
-  - echo "Running integration tests via protracor"
-  - export IMAGETESTED=`oc get pods -l app=oshinko-webui --template="{{range .items}}{{range .spec.containers}}{{.image}}{{end}}{{end}}"`
-  - echo "Testing image $IMAGETESTED"
   - |
       if [ "$TO_TEST" = "secure" ]; then
-        export TESTROUTE=`oc get route oshinko-web-oaproxy --template='{{.spec.host}}'`
+          WEBUI_START_XVFB=false  WEBUI_TEST_SECURE=true test/e2e.sh
       else
-        export TESTROUTE=`oc get route oshinko-web --template='{{.spec.host}}'`
-      fi
-  - echo TESTROUTE is $TESTROUTE
-  - echo "Waiting for proxy to come up"
-  - |
-      if [ "$TO_TEST" = "secure" ]; then
-        while [ 1 ]; do wget --no-check-certificate https://$TESTROUTE/proxy/api ; if [ $? = 0 ]; then break; fi; sleep 20s; done
-      else
-        while [ 1 ]; do wget  http://$TESTROUTE/proxy/api ; if [ $? = 0 ]; then break; fi; sleep 20s; done
-      fi
-  - cat api && rm api
-  - echo "Make sure that webui is up"
-  - export WEBCLUSTERIP=`oc get svc oshinko-web -o=go-template --template='{{.spec.clusterIP}}'`
-  - while [ 1 ]; do wget http://$WEBCLUSTERIP:8080/webui ; if [ $? = 0 ]; then break; fi; sleep 20s; done
-  - cat webui  && rm webui
-  - echo "Other environment details"
-  - echo "ENVIRONMENT IS:"
-  - env
-  - echo "ROUTES"
-  - oc get routes
-  - echo "SERVICES"
-  - oc get services
-  - echo "Protractor version is:"
-  - protractor --version
-  - |
-      if [ "$TO_TEST" = "secure" ]; then
-        protractor test/conf.js --baseUrl="https://$TESTROUTE/webui" --specs=test/spec/all-functionality.js
-      else
-        protractor test/conf.js --baseUrl="http://$TESTROUTE/webui" --specs=test/spec/all-functionality-insecure.js
+          WEBUI_START_XVFB=false test/e2e.sh
       fi
 ## uncomment the following 3 lines for debugging purposes
 #  - export PODNAME=`oc get pods --template='{{range .items}}{{.metadata.name}}{{end}}'`

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,6 @@ before_install:
   - echo ${IP}
   - IPSTR=`sudo oc login -u developer -p test`
   - echo $IPSTR
-  - echo "****Building oshinko-webui docker image****"
-  - docker build -t oshinko-webui .
   - echo "My token is set to-  $(oc whoami -t)"
 install:
   - npm install
@@ -80,9 +78,9 @@ before_script:
 script:
   - |
       if [ "$TO_TEST" = "secure" ]; then
-          WEBUI_START_XVFB=false  WEBUI_TEST_SECURE=true test/e2e.sh
+          WEBUI_START_XVFB=false make test-e2e-secure
       else
-          WEBUI_START_XVFB=false test/e2e.sh
+          WEBUI_START_XVFB=false make test-e2e
       fi
 ## uncomment the following 3 lines for debugging purposes
 #  - export PODNAME=`oc get pods --template='{{range .items}}{{.metadata.name}}{{end}}'`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-.PHONY : image
+.PHONY : image test-e2e test-e2e-secure
 
 image:
 	docker build -t oshinko-webui .
 
+test-e2e: image
+	test/e2e.sh
+
+test-e2e-secure: image
+	WEBUI_TEST_SECURE=true test/e2e.sh

--- a/README.md
+++ b/README.md
@@ -176,10 +176,29 @@ The `test/e2e.sh` script will create a serviceaccount,
 templates, a configmap, etc in the current project as part
 of the test.
 
+As a convenience, the *test-e2e* and *test-e2e-secure* make
+targets can be used to run the test. These targets will
+first build a local image and then run the test with defaults.
+For example:
+
 ```sh
 $ oc new-project mywebuitest
-$ test/e2e.sh
+$ make test-e2e
+...
+$
+$ oc new-project mysecuretest
+$ make test-e2e-secure
+...
 ```
+
+The environment variables below can be set for the call
+to make, for example:
+
+```sh
+$ WEBUI_START_XVFB=false make test-e2e
+```
+
+#### Environment variables for test configuration
 
 There are several enviroment variables that you can set
 to configure the tests:
@@ -249,7 +268,7 @@ $ WEBUI_TEST_INTEGRATED_REGISTRY=172.123.456.89:5000 test/e2e.sh
   may be a file path, or it may be a url such as
   https://radanalytics.io/resources.yaml.
 
-### Dependencies for end to end tests
+#### Dependencies for end to end tests
 
 The end to end tests require a number of dependencies.
 The `test/e2e-setup.sh` script has been provided to install

--- a/test/conf.js
+++ b/test/conf.js
@@ -6,5 +6,11 @@ exports.config = {
   allScriptsTimeout: 120000,
   jasmineNodeOpts: {
     defaultTimeoutInterval: 240000
+  },
+  params: {
+    securelogin: {
+      name: 'developer',
+      password: 'developerpass'
+    }
   }
 };

--- a/test/e2e-setup.sh
+++ b/test/e2e-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo dnf install -y which npm tar bzip2 wget
+sudo dnf install -y which npm tar bzip2 wget xorg-x11-server-Xvfb
 
 which bower
 if [ "$?" -ne 0 ]; then
@@ -15,8 +15,6 @@ which karma
 if [ "$?" -ne 0 ]; then
     sudo npm install -g karma-cli
 fi
-
-
 
 which java
 if [ "$?" -ne 0 ]; then

--- a/test/e2e-setup.sh
+++ b/test/e2e-setup.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# nodejs version 6 is needed for tests, so if you're on rhel you may have
+# to follow these instructions here.
+# https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora
+
 sudo dnf install -y which npm tar bzip2 wget xorg-x11-server-Xvfb
 
 which bower

--- a/test/e2e-setup.sh
+++ b/test/e2e-setup.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-# nodejs version 6 is needed for tests, so if you're on rhel you may have
-# to follow these instructions here.
-# https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora
+which dnf
+if [ "$?" -eq 0 ]; then
+    INSTALL=dnf
+else
+    INSTALL=yum
+fi
 
-sudo dnf install -y which npm tar bzip2 wget xorg-x11-server-Xvfb
+sudo $INSTALL install -y which npm tar bzip2 wget xorg-x11-server-Xvfb
 
 which bower
 if [ "$?" -ne 0 ]; then
@@ -23,7 +26,7 @@ fi
 
 which java
 if [ "$?" -ne 0 ]; then
-    sudo dnf install -y java-1.8.0-openjdk
+    sudo $INSTALL install -y java-1.8.0-openjdk
 fi
 
 which google-chrome-stable
@@ -37,8 +40,21 @@ gpgcheck=1
 gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub
 EOF'
 
-    sudo dnf install -y google-chrome-stable
+    sudo $INSTALL install -y google-chrome-stable
 fi
+
+nodeversion=$(node --version | cut -d '.' -f1)
+nodeversion="$((${nodeversion#v}))"
+if [ "$nodeversion" -lt 6 ]; then
+    echo
+    echo '****************************************************************************************************************************************'
+    echo Looks like your node version is less than 6 which is required for the test
+    echo You can follow these instructions to upgrade it https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora
+    echo '****************************************************************************************************************************************'
+    echo
+    exit 1
+fi
+
 
 sudo webdriver-manager update
 npm install

--- a/test/e2e-setup.sh
+++ b/test/e2e-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo dnf install which npm tar bzip2 wget
+sudo dnf install -y which npm tar bzip2 wget
 
 which bower
 if [ "$?" -ne 0 ]; then
@@ -16,11 +16,11 @@ if [ "$?" -ne 0 ]; then
     sudo npm install -g karma-cli
 fi
 
-which oc
+
+
+which java
 if [ "$?" -ne 0 ]; then
-    wget https://github.com/openshift/origin/releases/download/v3.6.1/openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit.tar.gz
-    tar -xvzf openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit.tar.gz
-    sudo cp openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit/oc /usr/local/bin
+    sudo dnf install -y java-1.8.0-openjdk
 fi
 
 which google-chrome-stable
@@ -40,3 +40,14 @@ fi
 sudo webdriver-manager update
 npm install
 bower install
+
+which docker
+if [ "$?" -ne 0 ]; then
+    echo *** Docker is not installed, it will be necessary to run the tests.
+fi
+
+
+which oc
+if [ "$?" -ne 0 ]; then
+    echo *** The 'oc' client is not installed, it will be necessary to run the tests
+fi

--- a/test/e2e-setup.sh
+++ b/test/e2e-setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+sudo dnf install which npm tar bzip2 wget
+
+which bower
+if [ "$?" -ne 0 ]; then
+    sudo npm install -g bower
+fi
+
+which protractor
+if [ "$?" -ne 0 ]; then
+    sudo npm install -g protractor
+fi
+
+which karma
+if [ "$?" -ne 0 ]; then
+    sudo npm install -g karma-cli
+fi
+
+which oc
+if [ "$?" -ne 0 ]; then
+    wget https://github.com/openshift/origin/releases/download/v3.6.1/openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit.tar.gz
+    tar -xvzf openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit.tar.gz
+    sudo cp openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit/oc /usr/local/bin
+fi
+
+which google-chrome-stable
+if [ "$?" -ne 0 ]; then
+    sudo bash -c 'cat << EOF > /etc/yum.repos.d/google-chrome.repo
+[google-chrome]
+name=google-chrome - \$basearch
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub
+EOF'
+
+    sudo dnf install -y google-chrome-stable
+fi
+
+sudo webdriver-manager update
+npm install
+bower install

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -142,7 +142,7 @@ function create_resources {
     set -e
 }
 
-function wait_for_proxy {
+function wait_for_webui {
     local command=
 
     try_until_success "oc get pods -l app=oshinko-webui"
@@ -159,12 +159,10 @@ function wait_for_proxy {
     echo "Waiting for proxy to come up"
     try_until_success "$command"
     cat api && rm api
-}
 
-function wait_for_webui {
     echo "Make sure that webui is up"
-    WEBCLUSTERIP=$(oc get svc oshinko-web --template='{{.spec.clusterIP}}')
-    try_until_success "wget http://$WEBCLUSTERIP:8080/webui"
+    WEBROUTE=$(oc get route oshinko-web --template='{{.spec.host}}')
+    try_until_success "wget http://$WEBROUTE/webui"
     cat webui  && rm webui
 }
 
@@ -197,7 +195,6 @@ check_for_xvfb
 tweak_template
 push_image
 create_resources
-wait_for_proxy
 wait_for_webui
 dump_env
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -107,18 +107,19 @@ function push_image {
 function tweak_template {
     if [ "$WEBUI_TEST_LOCAL_IMAGE" == true ] && [ -z "$WEBUI_TEST_INTEGRATED_REGISTRY" ] && [ -z "$WEBUI_TEST_EXTERNAL_REGISTRY" ]; then
 	echo Updating $WEBUI_TEST_RESOURCES to pull local webui image
+	mkdir -p `pwd`/test/scratch/
         if [ -f "$WEBUI_TEST_RESOURCES" ]; then
-            cp "$WEBUI_TEST_RESOURCES" `pwd`/resources_mod.yaml
+            cp "$WEBUI_TEST_RESOURCES" `pwd`/test/scratch/resources_mod.yaml
         else
-            wget "$WEBUI_TEST_RESOURCES" -O `pwd`/resources_mod.yaml	     
+            wget "$WEBUI_TEST_RESOURCES" -O `pwd`/test/scratch/resources_mod.yaml
         fi
         # This sed command finds the line with image: ${OSHINKO_WEB_IMAGE}
         # The next line sets the pull policy in the standard template (this should be maintained)
         # !b;n;s throws away the current processing, reads the next line, and starts a new substitution
         # Ultimately, this sets the pull policy for the web image to IfNotPresent so that an 'oc cluster up'
         # case can just reference the image from the host
-        sed -i -r '/image.*OSHINKO_WEB_IMAGE/!b;n;s/(.*imagePullPolicy: *)Always/\1IfNotPresent/' resources_mod.yaml
-        WEBUI_TEST_RESOURCES=`pwd`/resources_mod.yaml
+        sed -i -r '/image.*OSHINKO_WEB_IMAGE/!b;n;s/(.*imagePullPolicy: *)Always/\1IfNotPresent/' `pwd`/test/scratch/resources_mod.yaml
+        WEBUI_TEST_RESOURCES=`pwd`/test/scratch/resources_mod.yaml
     fi
 }
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+TOP_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"` | grep -o '.*/oshinko-webui')
+PROJECT=$(oc project -q)
+
+WEBUI_TEST_SECURE=${WEBUI_TEST_SECURE:-false}
+WEBUI_TEST_LOCAL_IMAGE=${WEBUI_TEST_LOCAL_IMAGE:-true}
+WEBUI_TEST_INTEGRATED_REGISTRY=${WEBUI_TEST_INTEGRATED_REGISTRY:-}
+WEBUI_TEST_EXTERNAL_REGISTRY=${WEBUI_TEST_EXTERNAL_REGISTRY:-}
+WEBUI_TEST_EXTERNAL_USER=${WEBUI_TEST_EXTERNAL_USER:-}
+WEBUI_TEST_EXTERNAL_PASSWORD=${WEBUI_TEST_EXTERNAL_PASSWORD:-}
+WEBUI_TEST_RESOURCES=${WEBUI_TEST_RESOURCES:-$TOP_DIR/tools/resources.yaml}
+if [ -z "$WEBUI_TEST_IMAGE" ]; then
+    if [ "$WEBUI_TEST_LOCAL_IMAGE" == true ]; then
+        WEBUI_TEST_IMAGE=oshinko-webui:latest
+    else
+        WEBUI_TEST_IMAGE=docker.io/radanalyticsio/oshinko-webui
+    fi
+fi
+
+function print_test_env {
+    echo Using image $WEBUI_TEST_IMAGE
+    echo Using resources.yaml from $WEBUI_TEST_RESOURCES
+
+    if [ "$WEBUI_TEST_LOCAL_IMAGE" != true ]; then
+	echo WEBUI_TEST_LOCAL_IMAGE = $WEBUI_TEST_LOCAL_IMAGE, webui image is external, ignoring registry env vars
+    elif [ -n "$WEBUI_TEST_EXTERNAL_REGISTRY" ]; then
+        echo Using external registry $WEBUI_TEST_EXTERNAL_REGISTRY
+        if [ -z "$WEBUI_TEST_EXTERNAL_USER" ]; then
+            echo "Error: WEBUI_TEST_EXTERNAL_USER not set!"
+	    exit 1
+        else
+	    echo Using external registry user $WEBUI_TEST_EXTERNAL_USER
+        fi
+        if [ -z "$WEBUI_TEST_EXTERNAL_PASSWORD" ]; then
+            echo "WEBUI_TEST_EXTERNAL_PASSWORD not set, assuming current docker login"
+        else
+            echo External registry password set
+        fi
+    elif [ -n "$WEBUI_TEST_INTEGRATED_REGISTRY" ]; then
+        echo Using integrated registry $WEBUI_TEST_INTEGRATED_REGISTRY
+    else
+        echo Not using external or integrated registry
+    fi
+}
+
+function push_image {
+    # The ip address of an internal/external registry may be set to support running against
+    # an openshift that is not "oc cluster up" when using images that have been built locally.
+    # In the case of "oc cluster up", the docker on the host is available from openshift so
+    # no special pushes of images have to be done.
+    # In the case of a "normal" openshift cluster, a local image we'll use for build has to be
+    # available from the designated registry.
+    # If we're using a pyspark image already in an external registry, openshift can pull it from
+    # there and we don't have to do anything.
+    local user=
+    local password=
+    local pushproj=
+    local pushimage=
+    local registry=
+    if [ "$WEBUI_TEST_LOCAL_IMAGE" == true ]; then
+	if [ -n  "$WEBUI_TEST_EXTERNAL_REGISTRY" ]; then
+	    user=$WEBUI_TEST_EXTERNAL_USER
+	    password=$WEBUI_TEST_EXTERNAL_PASSWORD
+	    pushproj=$user
+	    pushimage=scratch-oshinko-webui
+	    registry=$WEBUI_TEST_EXTERNAL_REGISTRY
+	elif [ -n "$WEBUI_TEST_INTEGRATED_REGISTRY" ]; then
+	    user=$(oc whoami)
+	    password=$(oc whoami -t)
+	    pushproj=$PROJECT
+	    pushimage=oshinko-webui
+	    registry=$WEBUI_TEST_INTEGRATED_REGISTRY
+	fi
+    fi
+    if [ -n "$registry" ]; then
+	set +e
+	docker login --help | grep email &> /dev/null
+	res=$?
+	set -e
+	if [ -n "$password" ]; then
+	    if [ "$res" -eq 0 ]; then
+		docker login -u ${user} -e jack@jack.com -p ${password} ${registry}
+	    else
+		docker login -u ${user} -p ${password} ${registry}
+	    fi
+	fi
+	docker tag ${WEBUI_TEST_IMAGE} ${registry}/${pushproj}/${pushimage}
+	docker push ${registry}/${pushproj}/${pushimage}
+	OSHINKO_WEB_IMAGE=${registry}/${pushproj}/${pushimage}
+    else
+	OSHINKO_WEB_IMAGE=$WEBUI_TEST_IMAGE
+    fi
+}
+
+function tweak_template {
+    if [ "$WEBUI_TEST_LOCAL_IMAGE" == true ] && [ -z "$WEBUI_TEST_INTEGRATED_REGISTRY" ] && [ -z "$WEBUI_TEST_EXTERNAL_REGISTRY" ]; then
+	echo Updating $WEBUI_TEST_RESOURCES to pull local webui image
+        if [ -f "$WEBUI_TEST_RESOURCES" ]; then
+            cp "$WEBUI_TEST_RESOURCES" `pwd`/resources_mod.yaml
+        else
+            wget "$WEBUI_TEST_RESOURCES" -O `pwd`/resources_mod.yaml	     
+        fi
+        # This sed command finds the line with image: ${OSHINKO_WEB_IMAGE}
+        # The next line sets the pull policy in the standard template (this should be maintained)
+        # !b;n;s throws away the current processing, reads the next line, and starts a new substitution
+        # Ultimately, this sets the pull policy for the web image to IfNotPresent so that an 'oc cluster up'
+        # case can just reference the image from the host
+        sed -i -r '/image.*OSHINKO_WEB_IMAGE/!b;n;s/(.*imagePullPolicy: *)Always/\1IfNotPresent/' resources_mod.yaml
+        WEBUI_TEST_RESOURCES=`pwd`/resources_mod.yaml
+    fi
+}
+
+# Modify the template if we're using a local image with no registry, i.e. we're in an oc cluster up case
+# In this case we don't need a push at all, but we to have a pullpolicy of IfNotPresent
+tweak_template
+print_test_env
+# Push the image if required
+push_image
+
+set +e
+oc create -f $WEBUI_TEST_RESOURCES
+oc policy add-role-to-user admin system:serviceaccount:$PROJECT:oshinko
+if [ "$WEBUI_TEST_SECURE" == true ]; then
+    oc new-app --template=oshinko-webui-secure -p OSHINKO_WEB_IMAGE=$OSHINKO_WEB_IMAGE
+else
+    oc new-app --template=oshinko-webui -p OSHINKO_WEB_IMAGE=$OSHINKO_WEB_IMAGE
+fi
+oc create configmap storedconfig --from-literal=mastercount=1 --from-literal=workercount=4
+set -e

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -53,6 +53,19 @@ function print_test_env {
         echo Not using external or integrated registry
     fi
     echo Start xvfb = $WEBUI_START_XVFB
+    echo Using secure oshinko webui $WEBUI_TEST_SECURE
+    if [ "$WEBUI_TEST_SECURE" == true ]; then
+        if [ -n "$WEBUI_TEST_SECURE_USER" ]; then
+            echo Using oshinko webui secure user $WEBUI_TEST_SECURE_USER
+        else
+            echo Using default oshinko webui secure user set in conf.js
+        fi
+        if [ -n "$WEBUI_TEST_SECURE_PASSWORD" ]; then
+            echo Oshinko webui secure password has been set
+        else
+            echo Using default oshinko webui secure password set in conf.js
+        fi
+    fi
 }
 
 function push_image {
@@ -62,7 +75,7 @@ function push_image {
     # no special pushes of images have to be done.
     # In the case of a "normal" openshift cluster, a local image we'll use for build has to be
     # available from the designated registry.
-    # If we're using a pyspark image already in an external registry, openshift can pull it from
+    # If we're using an image already in an external registry, openshift can pull it from
     # there and we don't have to do anything.
     local user=
     local password=
@@ -89,7 +102,7 @@ function push_image {
 	docker login --help | grep email &> /dev/null
 	res=$?
 	set -e
-	if [ -n "$password" ]; then
+	if [ -n "$password" ] && [ -n "$user" ]; then
 	    if [ "$res" -eq 0 ]; then
 		docker login -u ${user} -e jack@jack.com -p ${password} ${registry}
 	    else
@@ -201,7 +214,7 @@ function check_for_xvfb {
 }
 
 # Modify the template if we're using a local image with no registry, i.e. we're in an oc cluster up case
-# In this case we don't need a push at all, but we to have a pullpolicy of IfNotPresent
+# In this case we don't need a push at all, but we need to have a pullpolicy of IfNotPresent
 print_test_env
 check_for_xvfb
 tweak_template

--- a/test/spec/all-functionality.js
+++ b/test/spec/all-functionality.js
@@ -17,8 +17,8 @@ describe('Initial page functionality', function () {
     browser.waitForAngularEnabled(false);
     browser.get('/webui');
     element(by.tagName("button")).click();
-    element(by.name('username')).sendKeys("developer");
-    element(by.name('password')).sendKeys("developerpass");
+    element(by.name('username')).sendKeys(browser.params.securelogin.name);
+    element(by.name('password')).sendKeys(browser.params.securelogin.password);
     element(by.tagName("button")).click();
     element(by.name("approve")).click();
     browser.waitForAngularEnabled(true);


### PR DESCRIPTION
This change does an initial refactor of the integration test so that it can be
run using a local image or an external image. It adds a test/e2e.sh
script for running the test which handles the details of pushing
images to integrated/external registries or allowing the image
to be referenced directly from the host in the case of 'oc cluster up'.